### PR TITLE
Apply clippy suggestions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,11 +162,11 @@ impl Subscription {
         RequestSubscription::new(Source::Multicast)
     }
 
-    pub fn unicast_requests<'a>(from: Option<&'a dyn Authenticable>) -> RequestSubscription<'a> {
+    pub fn unicast_requests(from: Option<&dyn Authenticable>) -> RequestSubscription {
         RequestSubscription::new(Source::Unicast(from))
     }
 
-    pub fn unicast_responses<'a>(from: Option<&'a dyn Authenticable>) -> ResponseSubscription<'a> {
+    pub fn unicast_responses(from: Option<&dyn Authenticable>) -> ResponseSubscription {
         ResponseSubscription::new(Source::Unicast(from))
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -119,7 +119,7 @@ impl<'de> de::Deserialize<'de> for AuthnProperties {
             }
         }
 
-        const FIELDS: &'static [&'static str] = &["agent_label", "account_label", "audience"];
+        const FIELDS: &[&str] = &["agent_label", "account_label", "audience"];
         deserializer.deserialize_struct("AuthnProperties", FIELDS, AuthnPropertiesVisitor)
     }
 }


### PR DESCRIPTION
There's more:

```
warning: this argument is passed by reference, but would be more efficient if passed by value
   --> src/mqtt.rs:209:17
    |
209 |         status: &'static OutgoingResponseStatus,
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider passing by value instead: `OutgoingResponseStatus`
    |
    = note: #[warn(clippy::trivially_copy_pass_by_ref)] on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref

warning: this argument is passed by reference, but would be more efficient if passed by value
   --> src/mqtt.rs:281:17
    |
281 |         status: &'static OutgoingResponseStatus,
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider passing by value instead: `OutgoingResponseStatus`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref

warning: this argument is passed by reference, but would be more efficient if passed by value
   --> src/mqtt.rs:333:17
    |
333 |         status: &'static OutgoingResponseStatus,
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider passing by value instead: `OutgoingResponseStatus`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref

```

but I'm not sure why you made them static refs in the first place.