### PR TITLE
Serialize status as string

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -11,11 +11,17 @@ use crate::{
 
 #[derive(Deserialize, Serialize)]
 #[serde(remote = "http::StatusCode")]
-pub(crate) struct HttpStatusCodeRef(#[serde(getter = "http::StatusCode::as_u16")] u16);
+pub(crate) struct HttpStatusCodeRef(#[serde(getter = "http_status_code_to_string")] String);
+
+fn http_status_code_to_string(status_code: &http::StatusCode) -> String {
+    status_code.as_u16().to_string()
+}
 
 impl From<HttpStatusCodeRef> for http::StatusCode {
     fn from(value: HttpStatusCodeRef) -> http::StatusCode {
-        http::StatusCode::from_u16(value.0).unwrap()
+        use std::str::FromStr;
+
+        http::StatusCode::from_str(&value.0).unwrap()
     }
 }
 


### PR DESCRIPTION
In MQTT v5 all user properties must be UTF-8 strings => in MQTT v3 we also must have all values in `properties` object as strings including `status`.

Sending `status` as integer causes an error in the broker when sending the message to a client that uses MQTT v5.