### PR TITLE
Add local timestamp setter to outgoing request props

### DIFF
--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -1286,6 +1286,12 @@ pub struct OutgoingRequestProperties {
     short_term_timing: ShortTermTimingProperties,
     #[serde(flatten)]
     tracking: Option<TrackingProperties>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "ts_milliseconds_string_option"
+    )]
+    local_timestamp: Option<DateTime<Utc>>,
 }
 
 impl OutgoingRequestProperties {
@@ -1326,6 +1332,7 @@ impl OutgoingRequestProperties {
             long_term_timing: None,
             short_term_timing,
             tracking: None,
+            local_timestamp: None,
         }
     }
 
@@ -1341,6 +1348,11 @@ impl OutgoingRequestProperties {
 
     pub fn set_tracking(&mut self, tracking: TrackingProperties) -> &mut Self {
         self.tracking = Some(tracking);
+        self
+    }
+
+    pub fn set_local_timestamp(&mut self, local_timestamp: DateTime<Utc>) -> &mut Self {
+        self.local_timestamp = Some(local_timestamp);
         self
     }
 


### PR DESCRIPTION
`local_timestamp` is required by the broker for sending request in `default` connection mode (which is preferred for test agents simulating user actions) but there was no setter for it.