### PR TITLE
updated rumq with a version from git

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ serde_derive = "1.0"
 serde_json = "1.0"
 base64 = "0.10"
 diesel = { version = "1.4", features = ["postgres"], optional = true }
-rumq-client = "0.1.0-alpha.10"
+# 0.1.0-alpha.10 had a bug where max_max_packet_size was ignored
+rumq-client = {git = "https://github.com/tekjar/rumq", rev = "f765dc8"}
 http = "0.1"
 svc-authn = "0.6"
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
latest crates.io version has a bug where max_packet_size is ignored
so rumq aborts on large payloads